### PR TITLE
Use RGBColor insetad of Color.

### DIFF
--- a/src/specktre/colors.py
+++ b/src/specktre/colors.py
@@ -20,7 +20,7 @@ def random_color(start, end):
     d_blue = (start.blue - end.blue)
     while True:
         chosen_d = random.uniform(0, 1)
-        yield Color(
+        yield RGBColor(
             start.red - int(d_red * chosen_d),
             start.green - int(d_green * chosen_d),
             start.blue - int(d_blue * chosen_d)


### PR DESCRIPTION
Since Color is deprecated, `random_color` generates unnecessary warnings
that clutter user's stderr.

In my case, in tests, hundreds of them. 

I left `Color` in `generate_wallpapers.py` as this seems to be your private file, that is not part of the library. 

Thank you for this beautiful lib!