### PR TITLE
Fix for rounding error in generate_triangles

### DIFF
--- a/src/specktre/tilings.py
+++ b/src/specktre/tilings.py
@@ -66,7 +66,7 @@ def generate_unit_triangles(image_width, image_height):
     h = math.sin(math.pi / 3)
 
     for x in range(-1, image_width):
-        for y in range(int(image_height / h)):
+        for y in range(math.ceil(image_height / h)):
 
             # Add a horizontal offset on odd numbered rows
             x_ = x if (y % 2 == 0) else x + 0.5


### PR DESCRIPTION
This fixes a rounding bug in `generate_triangles` which causes the generated tiles to not properly fill the entire canvas.
Code to reproduce the problem:

```python
from specktre.tilings import generate_triangles
from specktre.colors import RGBColor, random_color

with Image.new("RGB", (200, 190), color="red") as img:
    draw = ImageDraw.Draw(img)

    colors = random_color(RGBColor(100, 100, 100), RGBColor(250, 250, 250))
    shapes = generate_triangles(img.width, img.height)
    for shape, colour in zip(shapes, colors):
        draw.polygon(shape, fill=(colour.red, colour.green, colour.blue))

    img.save("repro.png")

```

![repro](https://user-images.githubusercontent.com/104607/214513164-c2f9cb68-dd66-4993-a47f-d54d14358e06.png)

